### PR TITLE
ODPI-93 sync vagrant vm config with the docker config

### DIFF
--- a/bigtop-deploy/vm/vagrant-puppet-vm/vagrantconfig.yaml
+++ b/bigtop-deploy/vm/vagrant-puppet-vm/vagrantconfig.yaml
@@ -15,12 +15,12 @@
 
 memory_size: 4096
 number_cpus: 1
-box: "puppetlabs/centos-7.0-64-nocm"
-repo: "http://bigtop-repos.s3.amazonaws.com/releases/1.1.0/centos/7/x86_64"
+box: "puppetlabs/centos-6.6-64-nocm"
+repo: "http://build.odpi.org:8080/job/ODPi-v1.0-collect/lastSuccessfulBuild/artifact/1.0/centos-6"
 num_instances: 1
 distro: centos
 components: [hadoop, yarn]
 enable_local_repo: false
 run_smoke_tests: false
-smoke_test_components: [mapreduce, pig]
+smoke_test_components: [mapreduce,hcfs,hdfs,yarn]
 jdk: "java-1.7.0-openjdk-devel.x86_64"


### PR DESCRIPTION
Fixes ODPI-93:
- use the odpi yum repo
- set the centos6 base box
- set the correct smoke test components
