### PR TITLE
ODPI-61 add HADOOP_SUBPROJS spec test

### DIFF
--- a/bigtop-tests/spec-tests/runtime/src/test/resources/hadoop-subprojs.list
+++ b/bigtop-tests/spec-tests/runtime/src/test/resources/hadoop-subprojs.list
@@ -1,0 +1,4 @@
+hadoop-annotations.jar
+hadoop-auth.jar
+hadoop-common.jar
+hadoop-nfs.jar

--- a/bigtop-tests/spec-tests/runtime/src/test/resources/testRuntimeSpecConf.groovy
+++ b/bigtop-tests/spec-tests/runtime/src/test/resources/testRuntimeSpecConf.groovy
@@ -184,6 +184,14 @@ specs {
         referenceList = 'hadoop-yarn.list'
       }
     }
+    'HADOOP_SUBPROJS' {
+      name = 'HADOOP_SUBPROJS'
+      type = 'dirstruct'
+      arguments {
+        baseDirEnv = 'HADOOP_COMMON_HOME'
+        referenceList = 'hadoop-subprojs.list'
+      }
+    }
     'HADOOP_GETCONF' {
       name = 'HADOOP_GETCONF'
       type = 'shell'


### PR DESCRIPTION
Fixes ODPI-61 by testing for a picklist of jars in HADOOP_COMMON_HOME.
