### PR TITLE
Upgrade Spark to v2.0.0

### DIFF
--- a/bigtop-packages/src/common/spark/do-component-build
+++ b/bigtop-packages/src/common/spark/do-component-build
@@ -26,7 +26,7 @@ BUILD_OPTS="-Divy.home=${HOME}/.ivy2 -Dsbt.ivy.home=${HOME}/.ivy2 -Duser.home=${
             -Dprotobuf.version=2.5.0 \
             -DrecompileMode=all \
             -Pbigtop-dist \
-            -Pyarn -Phadoop-2.6 \
+            -Pyarn -Phadoop-2.7 \
             -Phive -Phive-thriftserver \
             $SPARK_BUILD_OPTS"
 

--- a/bigtop-packages/src/rpm/spark/SPECS/spark.spec
+++ b/bigtop-packages/src/rpm/spark/SPECS/spark.spec
@@ -196,12 +196,11 @@ done
 %{lib_spark}/RELEASE
 %{lib_spark}/NOTICE
 %{lib_spark}/bin
-%{lib_spark}/lib
-%exclude %{lib_spark}/lib/datanucleus-*.jar
-%exclude %{lib_spark}/lib/spark-*-yarn-shuffle.jar
+%{lib_spark}/jars
 %{lib_spark}/sbin
 %{lib_spark}/data
 %{lib_spark}/examples
+%{lib_spark}/licenses
 %{lib_spark}/work
 %exclude %{bin_spark}/pyspark
 %exclude %{lib_spark}/python
@@ -222,8 +221,8 @@ done
 
 %files -n spark-datanucleus
 %defattr(-,root,root,755)
-%{lib_spark}/lib/datanucleus-*.jar
-%{lib_spark}/yarn/lib/datanucleus-*.jar
+%{lib_spark}/jars/datanucleus-*.jar
+%{lib_spark}/yarn/datanucleus-*.jar
 
 %files -n spark-extras
 %defattr(-,root,root,755)
@@ -231,8 +230,7 @@ done
 
 %files -n spark-yarn-shuffle
 %defattr(-,root,root,755)
-%{lib_spark}/lib/spark-*-yarn-shuffle.jar
-%{lib_spark}/yarn/lib/spark-yarn-shuffle.jar
+%{lib_spark}/yarn/spark-*yarn-shuffle.jar
 
 %define service_macro() \
 %files -n %1 \

--- a/bigtop.bom
+++ b/bigtop.bom
@@ -37,8 +37,8 @@
  bigtop { // *the name should be change: the parsing code depends on it*
    version = "STACK-VERSION" // *required*
    stack { // *required* Fundamental properties of the Stack: JDK, SDK, GDK, etc
-     'jdk' { version = '1.7'; version_base = version }
-     'scala' { version = '2.10.4'; version_base = version }
+     'jdk' { version = '1.8'; version_base = version }
+     'scala' { version = '2.11.1'; version_base = version }
    }
    apache { // *required* These shoudn't be modified unless ASF Infra demands changes
      APACHE_MIRROR = "http://apache.osuosl.org"
@@ -69,8 +69,8 @@ bigtop {
 /** Base Configuration of the mirror and archives */
   version = "1.2.0-SNAPSHOT"
   stack {
-    'jdk' { version = '1.7'; version_base = version }
-    'scala' { version = '2.10.4'; version_base = version }
+    'jdk' { version = '1.8'; version_base = version }
+    'scala' { version = '2.11.1'; version_base = version }
   }
   apache {
     APACHE_MIRROR = "http://apache.osuosl.org"
@@ -93,7 +93,7 @@ bigtop {
       'phoenix', 'tachyon', 'kafka', 'ycsb', 'kite', 'hama', 'zeppelin',
       'tajo', 'apex'
     ],
-    hbase:['phoenix','giraph','ycsb'],
+    hbase:['phoenix','giraph','ycsb', 'hive'],
     pig:['datafu', 'oozie'],
     hive:['oozie', 'pig','zeppelin'],
     'ignite-hadoop':['zeppelin'],
@@ -122,7 +122,7 @@ bigtop {
     'hadoop' {
       name    = 'hadoop'
       relNotes = 'Apache Hadoop'
-      version { base = '2.7.1'; pkg = base; release = 1 }
+      version { base = '2.7.2'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/common/$name-${version.base}"
@@ -143,7 +143,7 @@ bigtop {
     'hbase' {
       name    = 'hbase'
       relNotes = 'Apache HBase'
-      version { base = '0.98.17'; pkg = base; release = 1 }
+      version { base = '1.1.3'; pkg = base; release = 1 }
       tarball { destination = "${name}-${version.base}.tar.gz"
                 source      = "${name}-${version.base}-src.tar.gz" }
       url     { download_path = "/$name/${version.base}/"
@@ -165,7 +165,7 @@ bigtop {
     'hive' {
       name    = 'hive'
       relNotes = 'Apache Hive'
-      version { base = '1.2.1'; pkg = base; release = 1 }
+      version { base = '2.1.0'; pkg = base; release = 1 }
       tarball { destination = "apache-${name}-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"
@@ -274,7 +274,7 @@ bigtop {
     'crunch' {
       name    = 'crunch'
       relNotes = 'Apache Crunch'
-      version { base = '0.12.0'; pkg = base; release = 1 }
+      version { base = '0.13.0'; pkg = base; release = 1 }
       tarball { destination = "apache-$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/"
@@ -285,7 +285,7 @@ bigtop {
       name    = 'spark'
       pkg     = 'spark-core'
       relNotes = 'Apache Spark'
-      version { base = '1.5.1'; pkg = base; release = 1 }
+      version { base = '2.0.0'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}.tgz" }
       url     { download_path = "/$name/$name-${version.base}"
@@ -300,8 +300,8 @@ bigtop {
        * to the base HBase version. Update as needed whenever changing the
        * HBase version in the BOM.
        */
-      phoenix.hbase ='HBase-0.98'
-      version { base = "4.6.0-${phoenix.hbase}"; pkg = '4.6.0'; release = 1 }
+      phoenix.hbase ='HBase-1.1'
+      version { base = "4.7.0-${phoenix.hbase}"; pkg = '4.7.0'; release = 1 }
       tarball { destination = "$name-${version.base}-src.tar.gz"
                 source      = destination }
       url     { download_path = "/$name/$name-${version.base}/src"
@@ -337,7 +337,7 @@ bigtop {
     'bigtop-tomcat' {
       name    = "bigtop-tomcat"
       relNotes = "Apache Tomcat"
-      version { base = '6.0.36'; pkg = base; release = 1 }
+      version { base = '6.0.45'; pkg = base; release = 1 }
       tarball { source      = "apache-tomcat-${version.base}-src.tar.gz"
                 destination = "apache-tomcat-${version.base}.tar.gz" }
       url     { download_path = "/tomcat/tomcat-6/v${version.base}/src"
@@ -415,7 +415,7 @@ bigtop {
     'apex' {
       name    = 'apex'
       relNotes = 'Apache Apex (incubating)'
-      version { base = '3.3.0'; pkg = base; release = 1 }
+      version { base = '3.4.0'; pkg = base; release = 1 }
       tarball { source      = "$name-${version.base}-incubating-source-release.tar.gz"
                 destination = "$name-${version.base}.tar.gz" }
       url     { download_path = "/incubator/$name/v${version.base}-incubating/"

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ allprojects {
   apply plugin: 'maven'
 
   group = 'org.apache.bigtop'
-  version = '1.2.0'
+  version = '2.1.0-SNAPSHOT'
 
   description = """Bigtop"""
 

--- a/odpi.bom
+++ b/odpi.bom
@@ -37,8 +37,8 @@
  bigtop { // *the name should be change: the parsing code depends on it*
    version = "STACK-VERSION" // *required*
    stack { // *required* Fundamental properties of the Stack: JDK, SDK, GDK, etc
-     'jdk' { version = '1.7'; version_base = version }
-     'scala' { version = '2.10.4'; version_base = version }
+     'jdk' { version = '1.8'; version_base = version }
+     'scala' { version = '2.11.1'; version_base = version }
    }
    apache { // *required* These shoudn't be modified unless ASF Infra demands changes
      APACHE_MIRROR = "http://apache.osuosl.org"
@@ -69,8 +69,8 @@ bigtop {
 /** Base Configuration of the mirror and archives */
   version = "1.0-SNAPSHOT"
   stack {
-    'jdk' { version = '1.7'; version_base = version }
-    'scala' { version = '2.10.4'; version_base = version }
+    'jdk' { version = '1.8'; version_base = version }
+    'scala' { version = '2.11.1'; version_base = version }
   }
   apache {
     APACHE_MIRROR = "http://apache.osuosl.org"
@@ -166,7 +166,7 @@ bigtop {
       name    = 'spark'
       pkg     = 'spark-core'
       relNotes = 'Apache Spark'
-      version { base = '1.5.1'; pkg = base; release = 1 }
+      version { base = '2.0.0'; pkg = base; release = 1 }
       tarball { destination = "$name-${version.base}.tar.gz"
                 source      = "$name-${version.base}.tgz" }
       url     { download_path = "/$name/$name-${version.base}"

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
   <inceptionYear>2011</inceptionYear>
 
   <properties>
-    <hadoop.version>2.6.0</hadoop.version>
+    <hadoop.version>2.7.2</hadoop.version>
     <!--An awful hack for BIGTOP-1429-->
-    <hbase.version>0.98.17-hadoop2</hbase.version>
+    <hbase.version>1.1.3</hbase.version>
     <pig.version>0.12.1</pig.version>
     <pig-smoke.version>0.12.1</pig-smoke.version>
     <sqoop.version>1.4.5</sqoop.version>
@@ -49,15 +49,15 @@
     <zookeeper.version>3.4.5</zookeeper.version>
     <giraph.version>1.0.0</giraph.version>
     <solr.version>4.6.0</solr.version>
-    <spark.version>1.3.1</spark.version>
+    <spark.version>2.0.0</spark.version>
     <kafka.version>0.8.1.1</kafka.version>
-    <phoenix.version>4.3.1</phoenix.version>
+    <phoenix.version>4.7.0</phoenix.version>
     <kite.version>1.1.0</kite.version>
     <spark-smoke.version>${project.version}</spark-smoke.version>
 
     <itest-common.version>${project.version}</itest-common.version>
 
-    <groovy.version>2.1.8</groovy.version>
+    <groovy.version>2.4.3</groovy.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <groovy-eclipse-compiler.version>2.8.0-01</groovy-eclipse-compiler.version>
     <gmaven.version>1.0</gmaven.version>
@@ -252,7 +252,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.10</artifactId>
+        <artifactId>spark-core_2.11</artifactId>
         <version>${spark.version}</version>
       </dependency>
        <dependency>


### PR DESCRIPTION
Upgrade Spark from 1.X.X to 2.0.0, and change the path's name and files'
name to keep align with Apache Spark.