### PR TITLE
ODPI-209 Fixed Hive unit tests (except TestHCatalog) to work with Hiv…

### DIFF
--- a/bigtop-tests/spec-tests/runtime/src/test/java/org/odpi/specs/runtime/hive/TestCLI.java
+++ b/bigtop-tests/spec-tests/runtime/src/test/java/org/odpi/specs/runtime/hive/TestCLI.java
@@ -30,8 +30,7 @@ import org.junit.Assert;
 public class TestCLI {
 	
 	static Map<String, String> results;
-	static String db = "javax.jdo.option.ConnectionURL=jdbc:derby:;databaseName=odpi_metastore_db;create=true";
-	
+
 	@BeforeClass
 	public static void setup(){
 		
@@ -40,32 +39,31 @@ public class TestCLI {
 	}
 	
 	@Test
-	public void help(){		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-H"));
-		//LOG.info(results.get("exitValue"));
+	public void help(){
+	  results = execHive("-H");
 		Assert.assertEquals("Error in executing 'hive -H'", 2, Integer.parseInt(results.get("exitValue")));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--help"));
+		results = execHive("--help");
 		Assert.assertEquals("Error in executing 'hive --help'", 0, Integer.parseInt(results.get("exitValue")));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-U"));
+		results = execHive("-U");
 		Assert.assertEquals("Unrecognized option should exit 1.", 1, Integer.parseInt(results.get("exitValue")));
 	}
 	 
 	@Test
 	public void sqlFromCmdLine(){
-		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
+
+	  results = execHive("-e", "SHOW DATABASES");
 		Assert.assertEquals("SHOW DATABASES command failed to execute.", 0, Integer.parseInt(results.get("exitValue")));
 		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+      results = execHive("-e", "CREATE DATABASE odpi_runtime_hive");
 			Assert.assertEquals("Could not create database odpi_runtime_hive.", 0, Integer.parseInt(results.get("exitValue")));
 		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+			results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
+			results = execHive("-e", "CREATE DATABASE odpi_runtime_hive");
 			Assert.assertEquals("Could not create database odpi_runtime_hive.", 0, Integer.parseInt(results.get("exitValue")));
 		}
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 	}
 	
 	@Test
@@ -74,34 +72,34 @@ public class TestCLI {
 		try(PrintWriter out = new PrintWriter("hive-f2.sql")){ out.println("CREATE DATABASE odpi_runtime_hive;"); }
 		try(PrintWriter out = new PrintWriter("hive-f3.sql")){ out.println("DROP DATABASE odpi_runtime_hive;"); out.println("CREATE DATABASE odpi_runtime_hive;"); }
 		try(PrintWriter out = new PrintWriter("hive-f4.sql")){ out.println("DROP DATABASE odpi_runtime_hive;"); }
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-f").addArgument("hive-f1.sql").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-f", "hive-f1.sql");
 		Assert.assertEquals("SHOW DATABASES command failed to execute.", 0, Integer.parseInt(results.get("exitValue")));
 		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-f").addArgument("hive-f2.sql").addArgument("--hiveconf").addArgument(db));
+			results = execHive("-f", "hive-f2.sql");
 			Assert.assertEquals("Could not create database odpi_runtime_hive.", 0, Integer.parseInt(results.get("exitValue")));
 		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-f").addArgument("hive-f3.sql").addArgument("--hiveconf").addArgument(db));
+			results = execHive("-f", "hive-f3.sql");
 			Assert.assertEquals("Could not create database odpi_runtime_hive.", 0, Integer.parseInt(results.get("exitValue")));
 		}
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-f").addArgument("hive-f4.sql").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-f", "hive-f4.sql");
 	}
 	
 	@Test
 	public void silent() {
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("-S").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("-S option did not work.", new Boolean(false), results.get("outputStream").contains("Time taken:"));
+		results = execHive("-e", "SHOW DATABASES", "-S");
+		Assert.assertEquals("-S option did not work.", false, results.get("outputStream").contains("Time taken:"));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--silent").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("--silent option did not work.", new Boolean(false), results.get("outputStream").contains("Time taken:"));
+		results = execHive("-e", "SHOW DATABASES", "--silent");
+		Assert.assertEquals("--silent option did not work.", false, results.get("outputStream").contains("Time taken:"));
 	}
 	
 	@Test
 	public void verbose(){
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("-v").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("-v option did not work.", new Boolean(true), results.get("outputStream").contains("SHOW DATABASES"));
+		results = execHive("-e", "SHOW DATABASES", "-v");
+		Assert.assertEquals("-v option did not work.", true, results.get("outputStream").contains("SHOW DATABASES"));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--verbose").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("--verbose option did not work.", new Boolean(true), results.get("outputStream").contains("SHOW DATABASES"));		
+		results = execHive("-e", "SHOW DATABASES", "--verbose");
+		Assert.assertEquals("--verbose option did not work.", true, results.get("outputStream").contains("SHOW DATABASES"));
 	}
 	
 	@Test
@@ -109,105 +107,90 @@ public class TestCLI {
 		try(PrintWriter out = new PrintWriter("hive-init1.sql")){ out.println("CREATE DATABASE odpi_runtime_hive;"); }
 		try(PrintWriter out = new PrintWriter("hive-init2.sql")){ out.println("DROP DATABASE odpi_runtime_hive;"); out.println("CREATE DATABASE odpi_runtime_hive;"); }
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "SHOW DATABASES");
 		Assert.assertEquals("SHOW DATABASES command failed to execute.", 0, Integer.parseInt(results.get("exitValue")));
 		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-i").addArgument("hive-init1.sql").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
+			results = execHive("-i", "hive-init1.sql", "-e", "SHOW DATABASES");
 			Assert.assertEquals("Could not create database odpi_runtime_hive using the init -i option.", 0, Integer.parseInt(results.get("exitValue")));
 			Assert.assertEquals("Could not create database odpi_runtime_hive using the init -i option.", true, results.get("outputStream").contains("odpi_runtime_hive"));
 		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-i").addArgument("hive-init2.sql").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
+			results = execHive("-i", "hive-init2.sql", "-e", "SHOW DATABASES");
 			Assert.assertEquals("Could not create database odpi_runtime_hive.", 0, Integer.parseInt(results.get("exitValue")));
 			Assert.assertEquals("Could not create database odpi_runtime_hive using the init -i option.", true, results.get("outputStream").contains("odpi_runtime_hive"));
 		}
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 	}
 	
 	@Test
 	public void database(){
-		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
-		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--database").addArgument("odpi_runtime_hive_1234").addArgument("-e").addArgument("CREATE TABLE odpi ( MYID INT );").addArgument("--hiveconf").addArgument(db));
+
+    results = execHive("-e", "CREATE DATABASE if not exists odpi_runtime_hive");
+		results = execHive("--database", "odpi_runtime_hive_1234", "-e", "CREATE TABLE odpi ( MYID INT );");
 		Assert.assertEquals("Non-existent database returned with wrong exit code: "+Integer.parseInt(results.get("exitValue")), 88, Integer.parseInt(results.get("exitValue")));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--database").addArgument("odpi_runtime_hive").addArgument("-e").addArgument("CREATE TABLE odpi ( MYID INT );").addArgument("--hiveconf").addArgument(db));
+		results = execHive("--database", "odpi_runtime_hive", "-e", "CREATE TABLE odpi ( MYID INT );");
 		Assert.assertEquals("Failed to create table using --database argument.", 0, Integer.parseInt(results.get("exitValue")));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--database").addArgument("odpi_runtime_hive").addArgument("-e").addArgument("DESCRIBE odpi").addArgument("--hiveconf").addArgument(db));
+		results = execHive("--database", "odpi_runtime_hive", "-e", "DESCRIBE odpi");
 		Assert.assertEquals("Failed to get expected column after creating odpi table using --database argument.", true, results.get("outputStream").contains("myid"));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--database").addArgument("odpi_runtime_hive").addArgument("-e").addArgument("DROP TABLE odpi").addArgument("--hiveconf").addArgument(db));
+		results = execHive("--database", "odpi_runtime_hive", "-e", "DROP TABLE odpi");
 		Assert.assertEquals("Failed to create table using --database argument.", 0, Integer.parseInt(results.get("exitValue")));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 	}
 	
 	@Test
 	public void hiveConf(){
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("--hiveconf").addArgument("hive.root.logger=INFO,console").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("The --hiveconf option did not work in setting hive.root.logger=INFO,console.", true, results.get("outputStream").contains("INFO parse.ParseDriver: Parsing command: SHOW DATABASES"));
-		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-hiveconf").addArgument("hive.root.logger=INFO,console").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
-		Assert.assertEquals("The -hiveconf variant option did not work in setting hive.root.logger=INFO,console.", true, results.get("outputStream").contains("INFO parse.ParseDriver: Parsing command: SHOW DATABASES"));
+		results = execHive("--hiveconf", "hive.root.logger=INFO,console", "-e", "SHOW DATABASES");
+		Assert.assertEquals("The --hiveconf option did not work in setting hive.root.logger=INFO,console.", true, results.get("outputStream").contains("ObjectStore, initialize called"));
 	}
 	
 	@Test
 	public void variableSubsitution() throws FileNotFoundException{
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
-		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}
+    results = execHive("-e", "CREATE DATABASE if not exists odpi_runtime_hive");
 		try(PrintWriter out = new PrintWriter("hive-define.sql")){ out.println("show ${A};"); out.println("quit;"); }
-		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("hive -d A=DATABASES --hiveconf '"+db+"' < hive-define.sql", false));		
+		results = execHive("-d", "A=DATABASES", "-f", "hive-define.sql");
 		Assert.assertEquals("The hive -d A=DATABASES option did not work.", 0, Integer.parseInt(results.get("exitValue")));
 		Assert.assertEquals("The hive -d A=DATABASES option did not work.", true, results.get("outputStream").contains("odpi_runtime_hive"));
 		
-		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("hive --define A=DATABASES --hiveconf '"+db+"' < hive-define.sql", false));		
-		Assert.assertEquals("The hive --define A=DATABASES option did not work.", 0, Integer.parseInt(results.get("exitValue")));
-		Assert.assertEquals("The hive --define A=DATABASES option did not work.", true, results.get("outputStream").contains("odpi_runtime_hive"));
-		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 	}
 	
 	@Test
 	public void hiveVar() throws FileNotFoundException{
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("SHOW DATABASES").addArgument("--hiveconf").addArgument(db));
-		if(!results.get("outputStream").contains("odpi_runtime_hive")){
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}else{
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-			results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("CREATE DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
-		}
+    results = execHive("-e", "CREATE DATABASE if not exists odpi_runtime_hive");
 		try(PrintWriter out = new PrintWriter("hive-var.sql")){ out.println("show ${A};"); out.println("quit;"); }
-		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("hive --hivevar A=DATABASES --hiveconf '"+db+"' < hive-var.sql", false));		
+		results = execHive("--hivevar", "A=DATABASES", "-f", "hive-var.sql");
 		Assert.assertEquals("The hive --hivevar A=DATABASES option did not work.", 0, Integer.parseInt(results.get("exitValue")));
 		Assert.assertEquals("The hive --hivevar A=DATABASES option did not work.", true, results.get("outputStream").contains("odpi_runtime_hive"));
 		
 		try(PrintWriter out = new PrintWriter("hiveconf-var.sql")){ out.println("show ${hiveconf:A};"); out.println("quit;"); }
-		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("hive --hiveconf A=DATABASES --hiveconf '"+db+"' < hiveconf-var.sql", false));		
+		results = execHive("--hiveconf", "A=DATABASES", "-f", "hiveconf-var.sql");
 		Assert.assertEquals("The hive --hiveconf A=DATABASES option did not work.", 0, Integer.parseInt(results.get("exitValue")));
 		Assert.assertEquals("The hive --hiveconf A=DATABASES option did not work.", true, results.get("outputStream").contains("odpi_runtime_hive"));
 		
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 	}
 	
 	@AfterClass
 	public static void cleanup(){
-		results = HiveHelper.execCommand(new CommandLine("hive").addArgument("-e").addArgument("DROP DATABASE odpi_runtime_hive").addArgument("--hiveconf").addArgument(db));
+		results = execHive("-e", "DROP DATABASE odpi_runtime_hive");
 		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("rm -rf hive-f*.sql", false));
 		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("rm -rf hive-init*.sql", false));
 		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("rm -rf hive-define.sql", false));
 		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("rm -rf hive-var.sql", false));
 		results = HiveHelper.execCommand(new CommandLine("/bin/sh").addArgument("-c").addArgument("rm -rf hiveconf-var.sql", false));
 	}
-	 
+
+  private static Map<String, String> execHive(String... args) {
+	  return HiveHelper.execCommand(new CommandLine("hive")
+        .addArguments(args)
+        .addArgument("--hiveconf")
+        .addArgument("datanucleus.schema.autoCreateAll=true")
+        .addArgument("--hiveconf")
+        .addArgument("hive.metastore.schema.verification=false")
+        .addArgument("--hiveconf")
+        .addArgument("javax.jdo.option.ConnectionURL=jdbc:derby:;databaseName=odpi_metastore_db;create=true"));
+  }
 }


### PR DESCRIPTION
…e 1 and 2.

TestHCatalog doesn't work because it includes Hive1 jars in it's job jars.  We'd have to build a separate test that runs the Hive2 jars in another module.

The only test that needed changes was HiveCLI, and this was driven by changes in config defaults that made it so that the metastore database was no longer automatically created.  I added config setting that are already the default on hive1 and on hive2 force it to create the metastore db so the tests can go ahead.  