### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-ANY/scripts/shared_initialization.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-ANY/scripts/shared_initialization.py
@@ -56,7 +56,7 @@ def setup_users():
   if params.has_hbase_masters:
     Directory (params.hbase_tmp_dir,
                owner = params.hbase_user,
-               mode=0775,
+               mode=0o775,
                create_parents = True,
                cd_access="a",
     )
@@ -128,7 +128,7 @@ def set_uid(user, user_dirs):
 
   File(format("{tmp_dir}/changeUid.sh"),
        content=StaticFile("changeToSecureUid.sh"),
-       mode=0555)
+       mode=0o555)
   ignore_groupsusers_create_str = str(params.ignore_groupsusers_create).lower()
   Execute(format("{tmp_dir}/changeUid.sh {user} {user_dirs}"),
           not_if = format("(test $(id -u {user}) -gt 1000) || ({ignore_groupsusers_create_str})"))
@@ -144,7 +144,7 @@ def setup_hadoop_env():
       tc_owner = params.hdfs_user
 
     # create /etc/hadoop
-    Directory(params.hadoop_dir, mode=0755)
+    Directory(params.hadoop_dir, mode=0o755)
 
     # HDP < 2.2 used a conf -> conf.empty symlink for /etc/hadoop/
     if Script.is_stack_less_than("2.2"):
@@ -165,7 +165,7 @@ def setup_hadoop_env():
     Directory(params.hadoop_java_io_tmpdir,
               owner=params.hdfs_user,
               group=params.user_group,
-              mode=01777
+              mode=0o1777
     )
 
 def setup_java():
@@ -216,7 +216,7 @@ def setup_java():
       Directory(tmp_java_dir, action="delete")
 
     File(format("{java_home}/bin/java"),
-         mode=0755,
+         mode=0o755,
          cd_access="a",
          )
     Execute(('chmod', '-R', '755', params.java_home),

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/files/topology_script.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/files/topology_script.py
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+from __future__ import print_function
 
 import sys, os
 from string import join
@@ -60,7 +61,7 @@ class TopologyScript():
   def execute(self, args):
     rack_map = self.load_rack_map()
     rack = self.get_racks(rack_map, args)
-    print rack
+    print(rack)
 
 if __name__ == "__main__":
   TopologyScript().execute(sys.argv)

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/params.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/params.py
@@ -237,7 +237,7 @@ hdfs_site = config['configurations']['hdfs-site']
 default_fs = config['configurations']['core-site']['fs.defaultFS']
 smoke_user =  config['configurations']['cluster-env']['smokeuser']
 smoke_hdfs_user_dir = format("/user/{smoke_user}")
-smoke_hdfs_user_mode = 0770
+smoke_hdfs_user_mode = 0o770
 
 
 ##### Namenode RPC ports - metrics config section start #####

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/rack_awareness.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/rack_awareness.py
@@ -37,7 +37,7 @@ def create_topology_script():
 
   File(params.net_topology_script_file_path,
        content=StaticFile('topology_script.py'),
-       mode=0755,
+       mode=0o755,
        only_if=format("test -d {net_topology_script_dir}"))
 
 def create_topology_script_and_mapping():

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/shared_initialization.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/shared_initialization.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
+from __future__ import print_function
 
 import os
 from resource_management.libraries.providers.hdfs_resource import WebHDFSUtil
@@ -63,7 +64,7 @@ def setup_hadoop():
       
     # if WebHDFS is not enabled we need this jar to create hadoop folders.
     if params.host_sys_prepped:
-      print "Skipping copying of fast-hdfs-resource.jar as host is sys prepped"
+      print("Skipping copying of fast-hdfs-resource.jar as host is sys prepped")
     elif params.dfs_type == 'HCFS' or not WebHDFSUtil.is_webhdfs_available(params.is_webhdfs_enabled, params.default_fs):
       # for source-code of jar goto contrib/fast-hdfs-resource
       File(format("{ambari_libs_dir}/fast-hdfs-resource.jar"),

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/shared_initialization.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/hooks/before-START/scripts/shared_initialization.py
@@ -40,7 +40,7 @@ def setup_hadoop():
               create_parents = True,
               owner='root',
               group=params.user_group,
-              mode=0775,
+              mode=0o775,
               cd_access='a',
     )
     if params.has_namenode:
@@ -67,7 +67,7 @@ def setup_hadoop():
     elif params.dfs_type == 'HCFS' or not WebHDFSUtil.is_webhdfs_available(params.is_webhdfs_enabled, params.default_fs):
       # for source-code of jar goto contrib/fast-hdfs-resource
       File(format("{ambari_libs_dir}/fast-hdfs-resource.jar"),
-           mode=0644,
+           mode=0o644,
            content=StaticFile("fast-hdfs-resource.jar")
       )
       
@@ -86,14 +86,14 @@ def setup_hadoop():
       log4j_filename = os.path.join(params.hadoop_conf_dir, "log4j.properties")
       if (params.log4j_props != None):
         File(log4j_filename,
-             mode=0644,
+             mode=0o644,
              group=params.user_group,
              owner=params.hdfs_user,
              content=params.log4j_props
         )
       elif (os.path.exists(format("{params.hadoop_conf_dir}/log4j.properties"))):
         File(log4j_filename,
-             mode=0644,
+             mode=0o644,
              group=params.user_group,
              owner=params.hdfs_user,
         )
@@ -118,7 +118,7 @@ def setup_configs():
     if os.path.exists(params.hadoop_conf_dir):
       File(params.task_log4j_properties_location,
            content=StaticFile("task-log4j.properties"),
-           mode=0755
+           mode=0o755
       )
 
     if os.path.exists(os.path.join(params.hadoop_conf_dir, 'configuration.xsl')):
@@ -161,7 +161,7 @@ def create_dirs():
                        type="directory",
                        action="create_on_execute",
                        owner=params.hdfs_user,
-                       mode=0777
+                       mode=0o777
    )
    params.HdfsResource(params.smoke_hdfs_user_dir,
                        type="directory",

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hcat.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hcat.py
@@ -67,7 +67,7 @@ def hcat():
             configuration_attributes=params.config['configuration_attributes']['hive-site'],
             owner=params.hive_user,
             group=params.user_group,
-            mode=0644)
+            mode=0o644)
 
   File(format("{hcat_conf_dir}/hcat-env.sh"),
        owner=params.hcat_user,

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hcat_service_check.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hcat_service_check.py
@@ -47,7 +47,7 @@ def hcat_service_check():
 
     File(format("{tmp_dir}/hcatSmoke.sh"),
          content=StaticFile("hcatSmoke.sh"),
-         mode=0755
+         mode=0o755
     )
 
     prepare_cmd = format("{kinit_cmd}env JAVA_HOME={java64_home} {tmp_dir}/hcatSmoke.sh hcatsmoke{unique} prepare {purge_tables}")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive.py
@@ -114,7 +114,7 @@ def hive(name=None):
                             type="directory",
                             action="create_on_execute",
                             owner=params.webhcat_user,
-                            mode=0755
+                            mode=0o755
                           )
     
     # Create webhcat dirs.
@@ -187,7 +187,7 @@ def hive(name=None):
                            type="directory",
                             action="create_on_execute",
                             owner=params.hive_user,
-                            mode=0777
+                            mode=0o777
       )
     else:
       Logger.info(format("Not creating warehouse directory '{hive_apps_whs_dir}', as the location is not in DFS."))
@@ -206,12 +206,12 @@ def hive(name=None):
                            action="create_on_execute",
                            owner=params.hive_user,
                            group=params.hdfs_user,
-                           mode=0777) # Hive expects this dir to be writeable by everyone as it is used as a temp dir
+                           mode=0o777) # Hive expects this dir to be writeable by everyone as it is used as a temp dir
       
     params.HdfsResource(None, action="execute")
 
   Directory(params.hive_etc_dir_prefix,
-            mode=0755
+            mode=0o755
   )
 
   # We should change configurations for client as well as for server.
@@ -226,7 +226,7 @@ def hive(name=None):
             configuration_attributes=params.config['configuration_attributes']['hive-site'],
             owner=params.hive_user,
             group=params.user_group,
-            mode=0644)
+            mode=0o644)
 
   # Generate atlas-application.properties.xml file
   if has_atlas_in_cluster():
@@ -240,7 +240,7 @@ def hive(name=None):
               configuration_attributes=params.config['configuration_attributes']['hiveserver2-site'],
               owner=params.hive_user,
               group=params.user_group,
-              mode=0644)
+              mode=0o644)
 
   if params.hive_metastore_site_supported and name == 'metastore':
     XmlConfig("hivemetastore-site.xml",
@@ -249,7 +249,7 @@ def hive(name=None):
               configuration_attributes=params.config['configuration_attributes']['hivemetastore-site'],
               owner=params.hive_user,
               group=params.user_group,
-              mode=0644)
+              mode=0o644)
   
   File(format("{hive_config_dir}/hive-env.sh"),
        owner=params.hive_user,
@@ -267,7 +267,7 @@ def hive(name=None):
   File(os.path.join(params.limits_conf_dir, 'hive.conf'),
        owner='root',
        group='root',
-       mode=0644,
+       mode=0o644,
        content=Template("hive.conf.j2")
        )
 
@@ -279,7 +279,7 @@ def hive(name=None):
 
   File(format("/usr/lib/ambari-agent/{check_db_connection_jar_name}"),
        content = DownloadSource(format("{jdk_location}{check_db_connection_jar_name}")),
-       mode = 0644,
+       mode = 0o644,
   )
 
   if name == 'metastore':
@@ -290,7 +290,7 @@ def hive(name=None):
     )
 
     File(params.start_metastore_path,
-         mode=0755,
+         mode=0o755,
          content=StaticFile('startMetastore.sh')
     )
     if params.init_metastore_schema:
@@ -321,7 +321,7 @@ def hive(name=None):
       )
   elif name == 'hiveserver2':
     File(params.start_hiveserver2_path,
-         mode=0755,
+         mode=0o755,
          content=Template(format('{start_hiveserver2_script}'))
     )
 
@@ -337,19 +337,19 @@ def hive(name=None):
               cd_access='a',
               owner=params.hive_user,
               group=params.user_group,
-              mode=0755)
+              mode=0o755)
     Directory(params.hive_log_dir,
               create_parents = True,
               cd_access='a',
               owner=params.hive_user,
               group=params.user_group,
-              mode=0755)
+              mode=0o755)
     Directory(params.hive_var_lib,
               create_parents = True,
               cd_access='a',
               owner=params.hive_user,
               group=params.user_group,
-              mode=0755)
+              mode=0o755)
 
 """
 Writes configuration files required by Hive.
@@ -369,7 +369,7 @@ def fill_conf_dir(component_conf_dir):
             configuration_attributes=params.config['configuration_attributes']['mapred-site'],
             owner=params.hive_user,
             group=params.user_group,
-            mode=0644)
+            mode=0o644)
 
 
   File(format("{component_conf_dir}/hive-default.xml.template"),
@@ -388,14 +388,14 @@ def fill_conf_dir(component_conf_dir):
     log4j_exec_filename = 'hive-exec-log4j.properties'
     if (params.log4j_exec_props != None):
       File(format("{component_conf_dir}/{log4j_exec_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=params.log4j_exec_props
       )
     elif (os.path.exists("{component_conf_dir}/{log4j_exec_filename}.template")):
       File(format("{component_conf_dir}/{log4j_exec_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=StaticFile(format("{component_conf_dir}/{log4j_exec_filename}.template"))
@@ -404,14 +404,14 @@ def fill_conf_dir(component_conf_dir):
     log4j_filename = 'hive-log4j.properties'
     if (params.log4j_props != None):
       File(format("{component_conf_dir}/{log4j_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=params.log4j_props
       )
     elif (os.path.exists("{component_conf_dir}/{log4j_filename}.template")):
       File(format("{component_conf_dir}/{log4j_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=StaticFile(format("{component_conf_dir}/{log4j_filename}.template"))
@@ -477,5 +477,5 @@ def jdbc_connector(target, hive_previous_jdbc_jar):
   pass
 
   File(target,
-       mode = 0644,
+       mode = 0o644,
   )

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_interactive.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_interactive.py
@@ -81,7 +81,7 @@ def hive_interactive(name=None):
       params.HdfsResource(None, action="execute")
 
   Directory(params.hive_interactive_etc_dir_prefix,
-            mode=0755
+            mode=0o755
             )
 
   Logger.info("Directories to fill with configs: %s" % str(params.hive_conf_dirs_list))
@@ -123,7 +123,7 @@ def hive_interactive(name=None):
             configuration_attributes=params.config['configuration_attributes']['tez-interactive-site'],
             owner = params.tez_interactive_user,
             group = params.user_group,
-            mode = 0664)
+            mode = 0o664)
 
   '''
   Merge properties from hiveserver2-interactive-site into hiveserver2-site
@@ -164,7 +164,7 @@ def hive_interactive(name=None):
                   configuration_attributes=params.config['configuration_attributes']['hive-interactive-site'],
                   owner=params.hive_user,
                   group=params.user_group,
-                  mode=0644)
+                  mode=0o644)
       else:
         XmlConfig("hive-site.xml",
                   conf_dir=conf_dir,
@@ -172,7 +172,7 @@ def hive_interactive(name=None):
                   configuration_attributes=params.config['configuration_attributes']['hive-interactive-site'],
                   owner=params.hive_user,
                   group=params.user_group,
-                  mode=0644)
+                  mode=0o644)
 
       XmlConfig("hiveserver2-site.xml",
                 conf_dir=conf_dir,
@@ -180,7 +180,7 @@ def hive_interactive(name=None):
                 configuration_attributes=params.config['configuration_attributes']['hiveserver2-interactive-site'],
                 owner=params.hive_user,
                 group=params.user_group,
-                mode=0644)
+                mode=0o644)
 
       hive_server_interactive_conf_dir = conf_dir
 
@@ -191,35 +191,35 @@ def hive_interactive(name=None):
 
       llap_daemon_log4j_filename = 'llap-daemon-log4j2.properties'
       File(format("{hive_server_interactive_conf_dir}/{llap_daemon_log4j_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=params.llap_daemon_log4j)
 
       llap_cli_log4j2_filename = 'llap-cli-log4j2.properties'
       File(format("{hive_server_interactive_conf_dir}/{llap_cli_log4j2_filename}"),
-           mode=0644,
+           mode=0o644,
            group=params.user_group,
            owner=params.hive_user,
            content=params.llap_cli_log4j2)
 
       hive_log4j2_filename = 'hive-log4j2.properties'
       File(format("{hive_server_interactive_conf_dir}/{hive_log4j2_filename}"),
-         mode=0644,
+         mode=0o644,
          group=params.user_group,
          owner=params.hive_user,
          content=params.hive_log4j2)
 
       hive_exec_log4j2_filename = 'hive-exec-log4j2.properties'
       File(format("{hive_server_interactive_conf_dir}/{hive_exec_log4j2_filename}"),
-         mode=0644,
+         mode=0o644,
          group=params.user_group,
          owner=params.hive_user,
          content=params.hive_exec_log4j2)
 
       beeline_log4j2_filename = 'beeline-log4j2.properties'
       File(format("{hive_server_interactive_conf_dir}/{beeline_log4j2_filename}"),
-         mode=0644,
+         mode=0o644,
          group=params.user_group,
          owner=params.hive_user,
          content=params.beeline_log4j2)
@@ -250,7 +250,7 @@ def hive_interactive(name=None):
   File(os.path.join(params.limits_conf_dir, 'hive.conf'),
        owner='root',
        group='root',
-       mode=0644,
+       mode=0o644,
        content=Template("hive.conf.j2"))
 
   if not os.path.exists(params.target_hive_interactive):
@@ -258,9 +258,9 @@ def hive_interactive(name=None):
 
   File(format("/usr/lib/ambari-agent/{check_db_connection_jar_name}"),
        content = DownloadSource(format("{jdk_location}{check_db_connection_jar_name}")),
-       mode = 0644)
+       mode = 0o644)
   File(params.start_hiveserver2_interactive_path,
-       mode=0755,
+       mode=0o755,
        content=Template(format('{start_hiveserver2_interactive_script}')))
 
   Directory(params.hive_pid_dir,
@@ -268,19 +268,19 @@ def hive_interactive(name=None):
             cd_access='a',
             owner=params.hive_user,
             group=params.user_group,
-            mode=0755)
+            mode=0o755)
   Directory(params.hive_log_dir,
             create_parents=True,
             cd_access='a',
             owner=params.hive_user,
             group=params.user_group,
-            mode=0755)
+            mode=0o755)
   Directory(params.hive_interactive_var_lib,
             create_parents=True,
             cd_access='a',
             owner=params.hive_user,
             group=params.user_group,
-            mode=0755)
+            mode=0o755)
 
 """
 Remove 'org.apache.atlas.hive.hook.HiveHook' value from Hive2/hive-site.xml config 'hive.exec.post.hooks', if exists.

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_metastore.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_metastore.py
@@ -225,7 +225,7 @@ class HiveMetastoreDefault(HiveMetastore):
           Execute(('cp', params.source_jdbc_file, target_directory),
             path=["/bin", "/usr/bin/"], sudo = True)
 
-      File(target_directory_and_filename, mode = 0644)
+      File(target_directory_and_filename, mode = 0o644)
 
     # build the schema tool command
     binary = format("{hive_schematool_ver_bin}/schematool")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_server_interactive.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_server_interactive.py
@@ -316,7 +316,7 @@ class HiveServerInteractiveDefault(HiveServerInteractive):
             parent_dir = os.path.dirname(run_file_path)
             if os.path.isdir(parent_dir):
               shutil.rmtree(parent_dir)
-          except Exception, e:
+          except Exception as e:
             Logger.error("Could not cleanup LLAP app package. Error: " + str(e))
 
         # throw the original exception
@@ -511,7 +511,7 @@ class HiveServerInteractiveDefault(HiveServerInteractive):
       try:
         status = do_retries()
         return status
-      except Exception, e:
+      except Exception as e:
         Logger.info("LLAP app '{0}' did not come up after a wait of {1} seconds.".format(llap_app_name,
                                                                                           time.time() - curr_time))
         traceback.print_exc()

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_server_upgrade.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/hive_server_upgrade.py
@@ -123,7 +123,7 @@ def _get_current_hiveserver_version():
       version_hive_bin = format('{stack_root}/{source_version}/hive/bin')
     command = format('{version_hive_bin}/hive --version')
     return_code, output = shell.call(command, user=params.hive_user, path=hive_execute_path)
-  except Exception, e:
+  except Exception as e:
     Logger.error(str(e))
     raise Fail('Unable to execute hive --version command to retrieve the hiveserver2 version.')
 

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/mysql_users.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/mysql_users.py
@@ -25,7 +25,7 @@ def mysql_adduser():
   import params
   
   File(params.mysql_adduser_path,
-       mode=0755,
+       mode=0o755,
        content=StaticFile('addMysqlUser.sh')
   )
   hive_server_host = format("{hive_server_host}")
@@ -49,7 +49,7 @@ def mysql_deluser():
   import params
   
   File(params.mysql_deluser_path,
-       mode=0755,
+       mode=0o755,
        content=StaticFile('removeMysqlUser.sh')
   )
   hive_server_host = format("{hive_server_host}")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/params_linux.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/params_linux.py
@@ -187,7 +187,7 @@ sqoop_tar_source = "{0}/{1}/sqoop/sqoop.tar.gz".format(STACK_ROOT_PATTERN, STACK
 hadoop_streaming_tar_dest_dir = "/{0}/apps/{1}/mapreduce/".format(STACK_NAME_PATTERN,STACK_VERSION_PATTERN)
 sqoop_tar_dest_dir = "/{0}/apps/{1}/sqoop/".format(STACK_NAME_PATTERN, STACK_VERSION_PATTERN)
 
-tarballs_mode = 0444
+tarballs_mode = 0o444
 
 purge_tables = "false"
 # Starting from stack version for feature hive_purge_table drop should be executed with purge
@@ -451,7 +451,7 @@ process_name = status_params.process_name
 hive_env_sh_template = config['configurations']['hive-env']['content']
 
 hive_hdfs_user_dir = format("/user/{hive_user}")
-hive_hdfs_user_mode = 0755
+hive_hdfs_user_mode = 0o755
 hive_apps_whs_dir = config['configurations']['hive-site']["hive.metastore.warehouse.dir"]
 whs_dir_protocol = urlparse(hive_apps_whs_dir).scheme
 hive_exec_scratchdir = config['configurations']['hive-site']["hive.exec.scratchdir"]
@@ -540,9 +540,9 @@ templeton_jar = config['configurations']['webhcat-site']['templeton.jar']
 webhcat_server_host = config['clusterHostInfo']['webhcat_server_host']
 
 hcat_hdfs_user_dir = format("/user/{hcat_user}")
-hcat_hdfs_user_mode = 0755
+hcat_hdfs_user_mode = 0o755
 webhcat_hdfs_user_dir = format("/user/{webhcat_user}")
-webhcat_hdfs_user_mode = 0755
+webhcat_hdfs_user_mode = 0o755
 #for create_hdfs_directory
 security_param = "true" if security_enabled else "false"
 

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/setup_ranger_hive.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/setup_ranger_hive.py
@@ -40,7 +40,7 @@ def setup_ranger_hive(upgrade_type = None):
                          action="create_on_execute",
                          owner=params.hdfs_user,
                          group=params.hdfs_user,
-                         mode=0755,
+                         mode=0o755,
                          recursive_chmod=True
       )
       params.HdfsResource("/ranger/audit/hiveServer2",
@@ -48,7 +48,7 @@ def setup_ranger_hive(upgrade_type = None):
                          action="create_on_execute",
                          owner=params.hive_user,
                          group=params.hive_user,
-                         mode=0700,
+                         mode=0o700,
                          recursive_chmod=True
       )
       params.HdfsResource(None, action="execute")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/setup_ranger_hive_interactive.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/setup_ranger_hive_interactive.py
@@ -40,7 +40,7 @@ def setup_ranger_hive_interactive(upgrade_type = None):
                          action="create_on_execute",
                          owner=params.hdfs_user,
                          group=params.hdfs_user,
-                         mode=0755,
+                         mode=0o755,
                          recursive_chmod=True
       )
       params.HdfsResource("/ranger/audit/hive2",
@@ -48,7 +48,7 @@ def setup_ranger_hive_interactive(upgrade_type = None):
                          action="create_on_execute",
                          owner=params.hive_user,
                          group=params.hive_user,
-                         mode=0700,
+                         mode=0o700,
                          recursive_chmod=True
       )
       params.HdfsResource(None, action="execute")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/webhcat.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/webhcat.py
@@ -50,13 +50,13 @@ def webhcat():
 
   Directory(params.templeton_pid_dir,
             owner=params.webhcat_user,
-            mode=0755,
+            mode=0o755,
             group=params.user_group,
             create_parents = True)
 
   Directory(params.templeton_log_dir,
             owner=params.webhcat_user,
-            mode=0755,
+            mode=0o755,
             group=params.user_group,
             create_parents = True)
 
@@ -125,14 +125,14 @@ def webhcat():
   log4j_webhcat_filename = 'webhcat-log4j.properties'
   if (params.log4j_webhcat_props != None):
     File(format("{config_dir}/{log4j_webhcat_filename}"),
-         mode=0644,
+         mode=0o644,
          group=params.user_group,
          owner=params.webhcat_user,
          content=params.log4j_webhcat_props
     )
   elif (os.path.exists("{config_dir}/{log4j_webhcat_filename}.template")):
     File(format("{config_dir}/{log4j_webhcat_filename}"),
-         mode=0644,
+         mode=0o644,
          group=params.user_group,
          owner=params.webhcat_user,
          content=StaticFile(format("{config_dir}/{log4j_webhcat_filename}.template"))

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/webhcat_service_check.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/HIVE/package/scripts/webhcat_service_check.py
@@ -78,7 +78,7 @@ def webhcat_service_check():
   import params
   File(format("{tmp_dir}/templetonSmoke.sh"),
        content= StaticFile('templetonSmoke.sh'),
-       mode=0755
+       mode=0o755
   )
 
   if params.security_enabled:

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/alerts/alert_nodemanager_health.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/alerts/alert_nodemanager_health.py
@@ -170,7 +170,7 @@ def execute(configurations={}, parameters={}, host_name=None):
       # execute the query for the JSON that includes templeton status
       url_response = urllib2.urlopen(query, timeout=connection_timeout)
       json_response = json.loads(url_response.read())
-  except urllib2.HTTPError, httpError:
+  except urllib2.HTTPError as httpError:
     label = CRITICAL_HTTP_STATUS_MESSAGE.format(str(httpError.code), query,
       str(httpError), traceback.format_exc())
 

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/alerts/alert_nodemanagers_summary.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/alerts/alert_nodemanagers_summary.py
@@ -140,7 +140,7 @@ def execute(configurations={}, parameters={}, host_name=None):
       try:
         url_response_json = json.loads(url_response)
         live_nodemanagers = json.loads(find_value_in_jmx(url_response_json, "LiveNodeManagers", live_nodemanagers_qry))
-      except ValueError, error:
+      except ValueError as error:
         convert_to_json_failed = True
         logger.exception("[Alert][{0}] Convert response to json failed or json doesn't contain needed data: {1}".
         format("NodeManager Health Summary", str(error)))

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/files/validateYarnComponentStatusWindows.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/files/validateYarnComponentStatusWindows.py
@@ -17,6 +17,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+from __future__ import print_function
 
 import optparse
 import subprocess
@@ -43,11 +44,11 @@ def getResponse(path, address, ssl_enabled):
     handle.close()
     response = json.loads(output)
     if response == None:
-      print 'There is no response for url: ' + str(url)
+      print('There is no response for url: ' + str(url))
       exit(1)
     return response
   except Exception as e:
-    print 'Error getting response for url:' + str(url), e
+    print('Error getting response for url:' + str(url), e)
     exit(1)
 
 #Verify that REST api is available for given component
@@ -59,7 +60,7 @@ def validateAvailability(component, path, address, ssl_enabled):
     if not is_valid:
       exit(1)
   except Exception as e:
-    print 'Error checking availability status of component', e
+    print('Error checking availability status of component', e)
     exit(1)
 
 #Validate component-specific response
@@ -70,7 +71,7 @@ def validateAvailabilityResponse(component, response):
       if rm_state == STARTED_STATE:
         return True
       else:
-        print 'Resourcemanager is not started'
+        print('Resourcemanager is not started')
         return False
 
     elif component == NODEMANAGER:
@@ -88,7 +89,7 @@ def validateAvailabilityResponse(component, response):
     else:
       return False
   except Exception as e:
-    print 'Error validation of availability response for ' + str(component), e
+    print('Error validation of availability response for ' + str(component), e)
     return False
 
 #Verify that component has required resources to work
@@ -100,7 +101,7 @@ def validateAbility(component, path, address, ssl_enabled):
     if not is_valid:
       exit(1)
   except Exception as e:
-    print 'Error checking ability of component', e
+    print('Error checking ability of component', e)
     exit(1)
 
 #Validate component-specific response that it has required resources to work
@@ -108,24 +109,24 @@ def validateAbilityResponse(component, response):
   try:
     if component == RESOURCEMANAGER:
       nodes = []
-      if response.has_key('nodes') and not response['nodes'] == None and response['nodes'].has_key('node'):
+      if 'nodes' in response and not response['nodes'] == None and 'node' in response['nodes']:
         nodes = response['nodes']['node']
       connected_nodes_count = len(nodes)
       if connected_nodes_count == 0:
-        print 'There is no connected nodemanagers to resourcemanager'
+        print('There is no connected nodemanagers to resourcemanager')
         return False
       active_nodes = filter(lambda x: x['state'] == RUNNING_STATE, nodes)
       active_nodes_count = len(active_nodes)
 
       if connected_nodes_count == 0:
-        print 'There is no connected active nodemanagers to resourcemanager'
+        print('There is no connected active nodemanagers to resourcemanager')
         return False
       else:
         return True
     else:
       return False
   except Exception as e:
-    print 'Error validation of ability response', e
+    print('Error validation of ability response', e)
     return False
 
 #

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/install_jars.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/install_jars.py
@@ -34,7 +34,7 @@ def install_tez_jars():
                            type="directory",
                            action="create_on_execute",
                            owner=params.tez_user,
-                           mode=0755
+                           mode=0o755
       )
 
     app_dir_path = None
@@ -63,7 +63,7 @@ def install_tez_jars():
                             type="file",
                             action="create_on_execute",
                             source=src_filepath,
-                            mode=0755,
+                            mode=0o755,
                             owner=params.tez_user
          )
         
@@ -74,7 +74,7 @@ def install_tez_jars():
                             type="file",
                             action="create_on_execute",
                             source=src_filepath,
-                            mode=0755,
+                            mode=0o755,
                             owner=params.tez_user
          )
     params.HdfsResource(None, action="execute")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/params_linux.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/params_linux.py
@@ -120,9 +120,9 @@ if stack_supports_timeline_state_store:
 
 # ats 1.5 properties
 entity_groupfs_active_dir = config['configurations']['yarn-site']['yarn.timeline-service.entity-group-fs-store.active-dir']
-entity_groupfs_active_dir_mode = 01777
+entity_groupfs_active_dir_mode = 0o1777
 entity_groupfs_store_dir = config['configurations']['yarn-site']['yarn.timeline-service.entity-group-fs-store.done-dir']
-entity_groupfs_store_dir_mode = 0700
+entity_groupfs_store_dir_mode = 0o700
 
 hadoop_conf_secure_dir = os.path.join(hadoop_conf_dir, "secure")
 
@@ -144,7 +144,7 @@ hdfs_tmp_dir = config['configurations']['hadoop-env']['hdfs_tmp_dir']
 
 smokeuser = config['configurations']['cluster-env']['smokeuser']
 smokeuser_principal = config['configurations']['cluster-env']['smokeuser_principal_name']
-smoke_hdfs_user_mode = 0770
+smoke_hdfs_user_mode = 0o770
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 nm_security_marker_dir = "/var/lib/hadoop-yarn"
 nm_security_marker = format('{nm_security_marker_dir}/nm_security_enabled')
@@ -155,7 +155,7 @@ smoke_user_keytab = config['configurations']['cluster-env']['smokeuser_keytab']
 yarn_executor_container_group = config['configurations']['yarn-site']['yarn.nodemanager.linux-container-executor.group']
 yarn_nodemanager_container_executor_class =  config['configurations']['yarn-site']['yarn.nodemanager.container-executor.class']
 is_linux_container_executor = (yarn_nodemanager_container_executor_class == 'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor')
-container_executor_mode = 06050 if is_linux_container_executor else 02050
+container_executor_mode = 0o6050 if is_linux_container_executor else 0o2050
 kinit_path_local = get_kinit_path(default('/configurations/kerberos-env/executable_search_paths', None))
 yarn_http_policy = config['configurations']['yarn-site']['yarn.http.policy']
 yarn_https_on = (yarn_http_policy.upper() == 'HTTPS_ONLY')

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/service.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/service.py
@@ -28,7 +28,7 @@ from resource_management.libraries.functions.show_logs import show_logs
 @OsFamilyFuncImpl(os_family=OSConst.WINSRV_FAMILY)
 def service(componentName, action='start', serviceName='yarn'):
   import status_params
-  if status_params.service_map.has_key(componentName):
+  if componentName in status_params.service_map:
     service_name = status_params.service_map[componentName]
     if action == 'start' or action == 'stop':
       Service(service_name, action=action)

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/setup_ranger_yarn.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/setup_ranger_yarn.py
@@ -34,7 +34,7 @@ def setup_ranger_yarn():
                          action="create_on_execute",
                          owner=params.hdfs_user,
                          group=params.hdfs_user,
-                         mode=0755,
+                         mode=0o755,
                          recursive_chmod=True
       )
       params.HdfsResource("/ranger/audit/yarn",
@@ -42,7 +42,7 @@ def setup_ranger_yarn():
                          action="create_on_execute",
                          owner=params.yarn_user,
                          group=params.yarn_user,
-                         mode=0700,
+                         mode=0o700,
                          recursive_chmod=True
       )
       params.HdfsResource(None, action="execute")

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/yarn.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/YARN/package/scripts/yarn.py
@@ -64,7 +64,7 @@ def yarn(name = None):
             mode='f'
   )
 
-  if params.service_map.has_key(name):
+  if name in params.service_map:
     service_name = params.service_map[name]
 
     ServiceConfig(service_name,
@@ -77,7 +77,7 @@ def create_log_dir(dir_name):
   Directory(dir_name,
             create_parents = True,
             cd_access="a",
-            mode=0775,
+            mode=0o775,
             owner=params.yarn_user,
             group=params.user_group,
             ignore_failures=True,
@@ -88,7 +88,7 @@ def create_local_dir(dir_name):
   Directory(dir_name,
             create_parents = True,
             cd_access="a",
-            mode=0755,
+            mode=0o755,
             owner=params.yarn_user,
             group=params.user_group,
             ignore_failures=True,
@@ -113,7 +113,7 @@ def yarn(name=None, config_dir=None):
                            type="directory",
                            owner=params.yarn_user,
                            group=params.user_group,
-                           mode=0777,
+                           mode=0o777,
                            recursive_chmod=True
       )
 
@@ -123,7 +123,7 @@ def yarn(name=None, config_dir=None):
                             action="create_on_execute",
                             type="directory",
                             owner=params.hdfs_user,
-                            mode=0777,
+                            mode=0o777,
         )
 
     params.HdfsResource(params.entity_file_history_directory,
@@ -148,7 +148,7 @@ def yarn(name=None, config_dir=None):
                          owner=params.mapred_user,
                          group=params.user_group,
                          change_permissions_for_parents=True,
-                         mode=0777
+                         mode=0o777
     )
     params.HdfsResource(None, action="execute")
     Directory(params.jhs_leveldb_state_store_dir,
@@ -192,14 +192,14 @@ def yarn(name=None, config_dir=None):
       File(params.nm_log_dir_to_mount_file,
            owner=params.hdfs_user,
            group=params.user_group,
-           mode=0644,
+           mode=0o644,
            content=nm_log_dir_to_mount_file_content
       )
       nm_local_dir_to_mount_file_content = handle_mounted_dirs(create_local_dir, params.nm_local_dirs, params.nm_local_dir_to_mount_file, params)
       File(params.nm_local_dir_to_mount_file,
            owner=params.hdfs_user,
            group=params.user_group,
-           mode=0644,
+           mode=0o644,
            content=nm_local_dir_to_mount_file_content
       )
   #</editor-fold>
@@ -209,7 +209,7 @@ def yarn(name=None, config_dir=None):
               owner=params.yarn_user,
               group=params.user_group,
               create_parents = True,
-              mode=0755,
+              mode=0o755,
               cd_access = 'a',
     )
 
@@ -240,7 +240,7 @@ def yarn(name=None, config_dir=None):
             configuration_attributes=params.config['configuration_attributes']['core-site'],
             owner=params.hdfs_user,
             group=params.user_group,
-            mode=0644
+            mode=0o644
   )
 
   # During RU, Core Masters and Slaves need hdfs-site.xml
@@ -253,7 +253,7 @@ def yarn(name=None, config_dir=None):
               configuration_attributes=params.config['configuration_attributes']['hdfs-site'],
               owner=params.hdfs_user,
               group=params.user_group,
-              mode=0644
+              mode=0o644
     )
 
   XmlConfig("mapred-site.xml",
@@ -262,7 +262,7 @@ def yarn(name=None, config_dir=None):
             configuration_attributes=params.config['configuration_attributes']['mapred-site'],
             owner=params.yarn_user,
             group=params.user_group,
-            mode=0644
+            mode=0o644
   )
 
   XmlConfig("yarn-site.xml",
@@ -271,7 +271,7 @@ def yarn(name=None, config_dir=None):
             configuration_attributes=params.config['configuration_attributes']['yarn-site'],
             owner=params.yarn_user,
             group=params.user_group,
-            mode=0644
+            mode=0o644
   )
 
   XmlConfig("capacity-scheduler.xml",
@@ -280,12 +280,12 @@ def yarn(name=None, config_dir=None):
             configuration_attributes=params.config['configuration_attributes']['capacity-scheduler'],
             owner=params.yarn_user,
             group=params.user_group,
-            mode=0644
+            mode=0o644
   )
 
   if name == 'resourcemanager':
     Directory(params.rm_nodes_exclude_dir,
-         mode=0755,
+         mode=0o755,
          create_parents=True,
          cd_access='a',
     )
@@ -304,7 +304,7 @@ def yarn(name=None, config_dir=None):
                            change_permissions_for_parents=True,
                            owner=params.yarn_user,
                            group=params.user_group,
-                           mode=0700
+                           mode=0o700
       )
       params.HdfsResource(None, action="execute")
 
@@ -334,7 +334,7 @@ def yarn(name=None, config_dir=None):
                           change_permissions_for_parents=True,
                           owner=params.yarn_user,
                           group=params.user_group,
-                          mode=0755
+                          mode=0o755
                           )
       params.HdfsResource(params.entity_groupfs_store_dir,
                           type="directory",
@@ -351,7 +351,7 @@ def yarn(name=None, config_dir=None):
                           change_permissions_for_parents=True,
                           owner=params.yarn_user,
                           group=params.user_group,
-                          mode=0755
+                          mode=0o755
                           )
       params.HdfsResource(params.entity_groupfs_active_dir,
                           type="directory",
@@ -363,19 +363,19 @@ def yarn(name=None, config_dir=None):
     params.HdfsResource(None, action="execute")
 
   File(format("{limits_conf_dir}/yarn.conf"),
-       mode=0644,
+       mode=0o644,
        content=Template('yarn.conf.j2')
   )
 
   File(format("{limits_conf_dir}/mapreduce.conf"),
-       mode=0644,
+       mode=0o644,
        content=Template('mapreduce.conf.j2')
   )
 
   File(os.path.join(config_dir, "yarn-env.sh"),
        owner=params.yarn_user,
        group=params.user_group,
-       mode=0755,
+       mode=0o755,
        content=InlineTemplate(params.yarn_env_sh_template)
   )
 
@@ -387,18 +387,18 @@ def yarn(name=None, config_dir=None):
 
   File(os.path.join(config_dir, "container-executor.cfg"),
       group=params.user_group,
-      mode=0644,
+      mode=0o644,
       content=Template('container-executor.cfg.j2')
   )
 
   Directory(params.cgroups_dir,
             group=params.user_group,
             create_parents = True,
-            mode=0755,
+            mode=0o755,
             cd_access="a")
 
   if params.security_enabled:
-    tc_mode = 0644
+    tc_mode = 0o644
     tc_owner = "root"
   else:
     tc_mode = None
@@ -406,7 +406,7 @@ def yarn(name=None, config_dir=None):
 
   File(os.path.join(config_dir, "mapred-env.sh"),
        owner=tc_owner,
-       mode=0755,
+       mode=0o755,
        content=InlineTemplate(params.mapred_env_sh_template)
   )
 
@@ -414,7 +414,7 @@ def yarn(name=None, config_dir=None):
     File(os.path.join(params.hadoop_bin, "task-controller"),
          owner="root",
          group=params.mapred_tt_group,
-         mode=06050
+         mode=0o6050
     )
     File(os.path.join(config_dir, 'taskcontroller.cfg'),
          owner = tc_owner,

--- a/bigtop-packages/src/common/ambari/ODPi/1.0/services/stack_advisor.py
+++ b/bigtop-packages/src/common/ambari/ODPi/1.0/services/stack_advisor.py
@@ -331,7 +331,7 @@ class ODPi10StackAdvisor(DefaultStackAdvisor):
     # dfs.datanode.du.reserved should be set to 10-15% of volume size
     # For each host selects maximum size of the volume. Then gets minimum for all hosts.
     # This ensures that each host will have at least one data dir with available space.
-    reservedSizeRecommendation = 0l #kBytes
+    reservedSizeRecommendation = 0 #kBytes
     for host in hosts["items"]:
       mountPoints = []
       mountPointDiskAvailableSpace = [] #kBytes
@@ -339,7 +339,7 @@ class ODPi10StackAdvisor(DefaultStackAdvisor):
         mountPoints.append(diskInfo["mountpoint"])
         mountPointDiskAvailableSpace.append(long(diskInfo["size"]))
 
-      maxFreeVolumeSizeForHost = 0l #kBytes
+      maxFreeVolumeSizeForHost = 0 #kBytes
       for dataDir in dataDirs:
         mp = getMountPointForDir(dataDir, mountPoints)
         for i in range(len(mountPoints)):

--- a/bigtop-tests/spec-tests/runtime/src/test/python/find-public-apis.py
+++ b/bigtop-tests/spec-tests/runtime/src/test/python/find-public-apis.py
@@ -17,6 +17,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+from __future__ import print_function
 
 import os
 import re
@@ -32,11 +33,11 @@ def main():
 
   # Get the ATS endpoint if it's not given.
   if options.directory == None:
-    print "You must specify a top level directory of the source tree"
+    print("You must specify a top level directory of the source tree")
     return 1
 
   if options.report == None:
-    print "You must specify the report to check against"
+    print("You must specify the report to check against")
     return 1
 
   publicClasses = set()
@@ -68,7 +69,7 @@ def main():
       classname = classre.group(1)
       if classname not in haveChecked:
         if classname in publicClasses:
-          print "Warning, found change in public class " + classname
+          print("Warning, found change in public class " + classname)
         haveChecked.add(classname)
   handle.close()
   


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.
* Old style octal constants (0775) --> new style (0o775) for Python 3
    * Python 3 treats old style octal constants as syntax errors but new style octal constants work as expected in both Python 2 and Python 3.